### PR TITLE
You need this imported to build

### DIFF
--- a/src/tools/ttimage_tools/md5.c
+++ b/src/tools/ttimage_tools/md5.c
@@ -16,6 +16,7 @@
  */
 
 #include "md5.h"
+#include "string.h"
 
 static void MD5Transform(unsigned int buf[4], unsigned int const in[16]);
 


### PR DESCRIPTION
Prevents these types of errors:
```
md5.c:74:7: warning: incompatible implicit declaration of built-in function ‘memmove’
md5.c:74:7: note: include ‘<string.h>’ or provide a declaration of ‘memmove’
```